### PR TITLE
Update ConnectSDKCordovaDispatcher.m

### DIFF
--- a/src/ios/ConnectSDKCordovaDispatcher.m
+++ b/src/ios/ConnectSDKCordovaDispatcher.m
@@ -347,9 +347,9 @@ static id orNull (id obj)
             id result = nil;
             
             if (sig.methodReturnLength > 0) { // FIXME verify type
-                result = objc_msgSend(self, sel, command);;
+                result = ((id(*)(id, SEL, id))objc_msgSend)(self, sel, command);
             } else {
-                objc_msgSend(self, sel, command);
+                ((id(*)(id, SEL, id))objc_msgSend)(self, sel, command);
             }
             
             if (result && [result isMemberOfClass:[ServiceSubscription class]]) {


### PR DESCRIPTION
@line 350, 352 -- updated syntax to support 64-bit encoding to fix on-device errors when sending commands via SDK (works ok in ios 64-bit emulator but fails when deployed on device). fix addresses this issue.
