### PR TITLE
[iOS] Fix displaying album art when playing media

### DIFF
--- a/src/ios/ConnectSDKCordovaDispatcher.m
+++ b/src/ios/ConnectSDKCordovaDispatcher.m
@@ -975,12 +975,8 @@ static id orNull (id obj)
     if (options) {
         title = options[@"title"];
         description = options[@"description"];
-        
-        NSString* iconUrlString = options[@"url"];
-        if (iconUrl) {
-            iconUrl = [NSURL URLWithString:iconUrlString];
-        }
-        
+        iconUrl = [NSURL URLWithString:options[@"iconUrl"]];
+
         if (options[@"shouldLoop"] == [NSNumber numberWithBool:YES]) {
             shouldLoop = YES;
         }


### PR DESCRIPTION
The album art parameter should be "iconUrl" (according to `playMedia` docs in https://github.com/ConnectSDK/Connect-SDK-Cordova-Plugin/blob/master/www/ConnectSDK.js#L1523 and Android version), but was "url" instead. This patch fixes that.

Fixes https://github.com/ConnectSDK/Connect-SDK-Cordova-Plugin/issues/20