### PR TITLE
Bugfix/discovery failed should trigger error

### DIFF
--- a/src/android/ConnectSDKCordova.java
+++ b/src/android/ConnectSDKCordova.java
@@ -256,7 +256,9 @@ public class ConnectSDKCordova extends CordovaPlugin {
                 e.printStackTrace();
             }
 
-            sendEvent(callbackContext, "error", errorObj);
+            PluginResult result = new PluginResult(PluginResult.Status.ERROR, errorObj);
+            result.setKeepCallback(true);
+            callbackContext.sendPluginResult(result);
         }
     }
 

--- a/src/android/DiscoveryManagerWrapper.java
+++ b/src/android/DiscoveryManagerWrapper.java
@@ -34,8 +34,6 @@ import com.connectsdk.discovery.DiscoveryManager.PairingLevel;
 import com.connectsdk.discovery.DiscoveryManagerListener;
 import com.connectsdk.service.command.ServiceCommandError;
 
-import android.util.Log;
-
 public class DiscoveryManagerWrapper implements DiscoveryManagerListener {
     ConnectSDKCordova plugin;
     DiscoveryManager discoveryManager;

--- a/src/android/DiscoveryManagerWrapper.java
+++ b/src/android/DiscoveryManagerWrapper.java
@@ -34,6 +34,8 @@ import com.connectsdk.discovery.DiscoveryManager.PairingLevel;
 import com.connectsdk.discovery.DiscoveryManagerListener;
 import com.connectsdk.service.command.ServiceCommandError;
 
+import android.util.Log;
+
 public class DiscoveryManagerWrapper implements DiscoveryManagerListener {
     ConnectSDKCordova plugin;
     DiscoveryManager discoveryManager;
@@ -114,8 +116,9 @@ public class DiscoveryManagerWrapper implements DiscoveryManagerListener {
 
     @Override
     public void onDiscoveryFailed(DiscoveryManager manager, ServiceCommandError error) {
-        // TODO Auto-generated method stub
-
+        if (callbackContext != null) {
+            plugin.sendErrorEvent(callbackContext, error);
+        }
     }
 
     public JSONObject getDeviceJSON(ConnectableDevice device) {


### PR DESCRIPTION
This adds `onDiscoveryFailed` implementation. Currently it can be called if you start an app with disabled WIFI. When this method is called it invokes javascript `DiscoveryManager._handleDiscoveryError()`