### PR TITLE
fix dependencies for android build

### DIFF
--- a/Connect-SDK-Android/build.gradle
+++ b/Connect-SDK-Android/build.gradle
@@ -67,10 +67,10 @@ dependencies {
 
     compile fileTree(dir: 'modules/firetv/libs', include: '*.jar')
 
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.android.support:appcompat-v7:22.2.1'
-    compile 'com.android.support:mediarouter-v7:22.2.1'
-    compile 'com.google.android.gms:play-services-cast:7.8.0'
+    compile 'com.android.support:support-v4:22.+'
+    compile 'com.android.support:appcompat-v7:22.+'
+    compile 'com.android.support:mediarouter-v7:22.+'
+    compile 'com.google.android.gms:play-services-cast:7.+'
 }
 
 apply from: 'maven-push.gradle'


### PR DESCRIPTION
fixes #35 
Update dependency versions to get the latest available for the specified SDK level.

Otherwise android build results in dependency not met errors whenever there is a new version released.

Build for android now works with the cordova sampler app with this update.