### PR TITLE
updated the connect-sdk-android tag to 1.6.2

### DIFF
--- a/Connect-SDK-Android/build.gradle
+++ b/Connect-SDK-Android/build.gradle
@@ -62,7 +62,7 @@ android {
 }
 
 dependencies {
-    compile files('core/libs/java-websocket-patch.jar')
+    compile files('core/libs/Java-WebSocket-1.3.7.jar')
     compile files('core/libs/javax.jmdns_3.4.1-patch2.jar')
 
     compile fileTree(dir: 'modules/firetv/libs', include: '*.jar')

--- a/scripts/android-install.js
+++ b/scripts/android-install.js
@@ -16,7 +16,7 @@ var commands = {
 
 var paths = {
 	"ConnectSDK_Repository": "https://github.com/ConnectSDK/Connect-SDK-Android.git",
-	"ConnectSDK_Tag": "tags/1.6.0",
+	"ConnectSDK_Tag": "1.6.2",
 	"FlingSDK_URL": "https://s3-us-west-1.amazonaws.com/amazon-fling/AmazonFling-SDK.zip",
 	"AmazonFling_Jar": "./csdk_tmp/android-sdk/lib/AmazonFling.jar",
 	"WhisperPlay_Jar": "./csdk_tmp/android-sdk/lib/android/WhisperPlay.jar"


### PR DESCRIPTION
Issue Resolved / Feature Added
cordova failure

Resolution
Changed the tag from tag/1.6.0 to 1.6.2

Additional Considerations

Links
PLAT-54918

Comments
Enact-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)