### PR TITLE
updated connect-sdk-ios tag to 1.6.0

### DIFF
--- a/scripts/ios-install.js
+++ b/scripts/ios-install.js
@@ -21,7 +21,7 @@ if (!isMac) {
 
 	var paths = {
 		"ConnectSDK_Framework": "http://github.com/ConnectSDK/Connect-SDK-iOS/releases/download/1.6.0/ConnectSDK.framework.zip",
-		"ConnectSDK_Version": "tags/1.6.0",
+		"ConnectSDK_Version": "1.6.0",
 		"FlingSDK_URL": "https://s3-us-west-1.amazonaws.com/amazon-fling/AmazonFling-SDK.zip",
 		"AmazonFling_Framework": "./csdk_tmp/ios-sdk/frameworks/AmazonFling.framework",
 		"Bolts_Framework": "./csdk_tmp/ios-sdk/frameworks/third_party_framework/Bolts.framework",


### PR DESCRIPTION
Issue Resolved / Feature Added
cordova failure

Resolution
Changed the IOS tag from tag/1.6.0 to 1.6.0

Additional Considerations

Links
PLAT-54918

Comments
Enact-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)